### PR TITLE
Fix download of cached files in Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -69,6 +69,13 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
       request.onsuccess = function (event) {
         let result = this.result
 
+        // Generate new urls as they do not last
+        result = result.map(function (res) {
+          return Object.assign(res, {
+            url: window.URL.createObjectURL(res.blob)
+          })
+        })
+
         debugLog('Got data back', result)
         chrome.runtime.sendMessage({action: 'returnFilesInfo', entries: result})
       }

--- a/background.js
+++ b/background.js
@@ -69,13 +69,6 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
       request.onsuccess = function (event) {
         let result = this.result
 
-        // Generate new urls as they do not last
-        result = result.map(function (res) {
-          return Object.assign(res, {
-            url: window.URL.createObjectURL(res.blob)
-          })
-        })
-
         debugLog('Got data back', result)
         chrome.runtime.sendMessage({action: 'returnFilesInfo', entries: result})
       }

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -728,7 +728,7 @@ function searchUpdate() {
 
     link.click(function (e) {
       chrome.downloads.download({
-        url : window.URL.createObjectURL(entry.blob),
+        url : entry.url,
         filename: entry.displayName
       })
     })

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -722,24 +722,39 @@ $("#searchBox").keydown(function(e) {
 function searchUpdate() {
 	var searchQuery = $("#searchBox").val();
 
-	var list = "";
+	function generateListElement (entry, fileName) {
+		let element = $('<li/>').addClass('list-group-item')
+    let link = $('<a/>').attr('href', '#').html(fileName)
+
+    link.click(function (e) {
+      chrome.downloads.download({
+        url : window.URL.createObjectURL(entry.blob),
+        filename: entry.displayName
+      })
+    })
+
+    return element.append(link)
+  }
+
+	var list = [];
+
 	if (searchQuery == "") {
 		entries.forEach(function(entry, i) {
 			var fileName = entry.name.replace(fileMatch, "");
-			list = list + "<li class='list-group-item'><a target='_blank' download='" + entry.displayName + "' href='" + entry.url + "' >" + fileName + "</a></li>";
+      list.push(generateListElement(entry, fileName));
 		});
 	} else {
 		entries.forEach(function(entry, i) {
 			var fileName = entry.name.replace(fileMatch, "");
 			if (fileName.toUpperCase().includes(searchQuery.toUpperCase())) {
 				fileName = fileName.replace(new RegExp("(" + searchQuery + ")", 'ig'), '<b>$1</b>');
-				list = list + "<li class='list-group-item'><a target='_blank' href=" + entry.url + ">" + fileName + "</a></li>";
+        list.push(generateListElement(entry, fileName));
 			}
 		});
 
 	}
 
-	document.getElementById("searchResults").innerHTML = list;
+  $('#searchResults').html(list)
 }
 
 $("#searchBox").bind('input', searchUpdate);

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,8 @@
 		"*://*.uddataplus.dk/*",
 		"storage",
 		"tabs",
-		"unlimitedStorage"
+		"unlimitedStorage",
+		"downloads"
 	],
 	"background":{
 		"scripts":["storageHandler.js", "resources/jquery-3.1.0.min.js", "resources/fullcalendar-3.1.0/lib/moment.min.js", "UD++Functions.js", "background.js"]

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
 	"name": "UD++",
 	"description": "An extension that makes the experience of using uddata+ better",
-	"version": "2.1.1",
+	"version": "2.3.0",
 	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
 	"options_ui":{
 		"page": "options/options.html",


### PR DESCRIPTION
Right now file download works in Firefox but not in Chrome.
This is because blobs can't be passed from background.js to dashboard.js
through "chrome.runtime.sendMessage" in Chrome, this does however work in Firefox.

Possible fix would be to use the previous code for Chrome and the new
for Firefox, is there a way to detect wich browser is being used?